### PR TITLE
add -pthread flag for Linux to kisymgen Makefile

### DIFF
--- a/kisymgen/kisymgen_src/Makefile
+++ b/kisymgen/kisymgen_src/Makefile
@@ -50,7 +50,7 @@ ifeq ($(UNAME_S), Linux) #LINUX
 	ECHO_MESSAGE = "Linux"
 	LIBS += -lGL `pkg-config --static --libs glfw3`
 
-	CXXFLAGS += `pkg-config --cflags glfw3`
+	CXXFLAGS += `pkg-config --cflags glfw3` -pthread
 	CFLAGS = $(CXXFLAGS)
 endif
 


### PR DESCRIPTION
This change was necessary for me to avoid this error during build
```
/usr/bin/ld: /usr/local/lib/libglfw3.a(posix_thread.c.o): undefined reference to symbol 'pthread_key_delete@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
```
Ubuntu 16.04 LTS
kernel 4.4.0-174-generic #204-Ubuntu SMP Wed Jan 29 06:41:01 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

